### PR TITLE
Convert to zeta version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # Theta
 
 a code for relation extraction...
+
+For 2080Ti
+
+```bash
+python main.py --output /data2021/zwj/theta/output
+```
+
+For xJobs
+
+```bash
+python xjobs.py --output /data2021/zwj/theta/output
+```

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -90,7 +90,7 @@ class Config(SimpleConfig):
 
     def handle_config(self):
         # 确认 tag，如果是函数传参调用的模式，就不需要确认 tag
-        if not self.with_ext_config or self.no_borther_confirm:
+        if not self.with_ext_config and not self.no_borther_confirm:
             self.tag = utils.confirm_value("tag", self.tag)
 
             if self.debug and self.wandb:

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -98,13 +98,11 @@ class Config(SimpleConfig):
 
         # 创建此次实验的基本信息，运行时间，输出路径
         self.start = time.strftime("%Y-%m-%d_%H-%M-%S", time.localtime())
-        self.output_dir = os.path.join(
-            self.output, f"ouput-{self.start}-{self.tag}")
+        self.output_dir = os.path.join(self.output, f"ouput-{self.start}-{self.tag}")
         os.makedirs(self.output_dir, exist_ok=True)
 
         if self.debug and not self.test_from_ckpt:
-            self.output_dir = os.path.join(
-                self.output, "debug", f"{self.start}-{self.tag}")
+            self.output_dir = os.path.join(self.output, "debug", f"{self.start}-{self.tag}")
             os.makedirs(self.output_dir, exist_ok=True)
 
         # 处理参数冲突

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -6,6 +6,7 @@ project: theta
 tag: default
 
 # INFO: Run
+num_worker: 12
 batch_size: 16 # can be overrided by model.yaml
 lr: 0.00003
 # decoder_lr: 0.00003

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -28,14 +28,18 @@ context_window: 200  # make sure that context_window < max_seq_len
 dataset_config: datasets/ace2005/ace2005.yaml # can not be modified in ext_config
 
 # INFO: sub-task
-use_span: "" # lmhead, multi_classifier
 use_ner: "lmhead"
 use_rel_cls: "lmhead"
-use_two_stage: False
-use_independent_plm: False
-use_rel_mask: False
+use_two_stage: True
+use_independent_plm: True
+use_2d_attention_mask: True
+mask_token_position: "sub"
+
+use_rel_mask: True # Set As True
 
 use_ent_corres: "" # deprecated
 use_rel_maps: "" # deprecated
 use_ent_type_in_rel: False # deprecated
 use_crf: False # deprecated
+use_span: "" # lmhead, multi_classifier
+use_entity_pair_filter: True # removed

--- a/models/components.py
+++ b/models/components.py
@@ -196,6 +196,7 @@ class REModel(pl.LightningModule):
         if len(ent_groups) != 0:
             # 构建 rel_stage_hs, ent [batch_idx, sub_start, sub_end, end_start, end_end, sub_type, end_type]
             for ent in ent_groups:
+                sent_s = pos[ent[0], 0]
                 sub_hidden_state = rel_stage_hs[ent[0], ent[1]-sent_s+1]
                 obj_hidden_state = rel_stage_hs[ent[0], ent[3]-sent_s+1]
 

--- a/models/components.py
+++ b/models/components.py
@@ -294,7 +294,7 @@ class REModel(pl.LightningModule):
             plm_model = plm_model.cuda() # 不知道为什么是 CPU，可能是因为 debug mode
             outputs = plm_model(
                 rel_input_ids,
-                attention_mask=rel_attention_mask_matrix,
+                attention_mask=rel_attention_mask,
                 position_ids=rel_positional_ids,
                 output_hidden_states=True
                 )

--- a/models/theta.py
+++ b/models/theta.py
@@ -196,23 +196,30 @@ class Theta(pl.LightningModule):
 
             # 如果是训练阶段，使用 gold triples 计算损失，如果不是，仅保存预测的 triples 用于评估
             entities = self.ner_model.decode_entities(ent_maps, pos=pos) # gold entities
-            rel_output = self.rel_model.prepare(self, batch, hidden_state, triples, entities)
-            ent_groups, rel_hidden_states, triple_labels, filter_loss = rel_output
-
-            rel_logits, rel_loss = self.rel_model(rel_hidden_states, labels=triple_labels)
-            triples_pred = [ent_groups[i] + [rel_logits[i].argmax().item()] for i in range(len(ent_groups))]
-            output["triples_pred_with_gold"] = triples_pred
-
-            if mode != "train":
-                # 如果是测试阶段，使用预测的 triples
-                entities = self.ner_model.decode_entities(ner_logits, pos=pos) # gold entities
+            if sum([len(e) for e in entities]) > 0:
                 rel_output = self.rel_model.prepare(self, batch, hidden_state, triples, entities)
-                ent_groups, rel_hidden_states, triple_labels = rel_output[:3]
+                ent_groups, rel_hidden_states, triple_labels, filter_loss = rel_output
 
                 rel_logits, rel_loss = self.rel_model(rel_hidden_states, labels=triple_labels)
                 triples_pred = [ent_groups[i] + [rel_logits[i].argmax().item()] for i in range(len(ent_groups))]
+                output["triples_pred_with_gold"] = triples_pred
+            else:
+                rel_loss = torch.tensor(0.0, device=input_ids.device)
+                filter_loss = torch.tensor(0.0, device=input_ids.device)
+                output["triples_pred_with_gold"] = []
 
-                output["triples_pred"] = triples_pred
+            if mode != "train":
+                # 如果是测试阶段，使用预测的 triples
+                entities = self.ner_model.decode_entities(ner_logits, pos=pos) # pred entities
+                if sum([len(e) for e in entities]) > 0:
+                    rel_output = self.rel_model.prepare(self, batch, hidden_state, triples, entities)
+                    ent_groups, rel_hidden_states, triple_labels = rel_output[:3]
+                    rel_logits, rel_loss = self.rel_model(rel_hidden_states, labels=triple_labels)
+                    triples_pred = [ent_groups[i] + [rel_logits[i].argmax().item()] for i in range(len(ent_groups))]
+                    output["triples_pred"] = triples_pred
+                else:
+                    rel_loss = torch.tensor(0.0, device=input_ids.device)
+                    output["triples_pred"] = []
 
         # 计算损失
         if mode != "test":

--- a/xjobs.py
+++ b/xjobs.py
@@ -8,14 +8,20 @@ import utils
 run_id = "RUN_{}".format(time.strftime("%Y%m%d-%H%M%S"))
 
 
-index = ["seed", "lr"]
-run_config = {
-    "tag": "lambda",
-    "lr": [1e-4, 3e-5, 8e-6, 3e-6],
-    "seed": [42, 43],
-}
-
-run_configs = []
+index = []
+run_config = {}
+run_configs = [
+    {
+        "tag": "lambda-no-win-two-sep",
+        "use_two_stage": True,
+        "use_independent_plm": True,
+    },
+    {
+        "tag": "lambda-no-win-two",
+        "use_two_stage": True,
+        "use_independent_plm": False,
+    }
+]
 
 
 def get_gpu_by_user_input():
@@ -52,6 +58,7 @@ def get_all_combinations(run_config):
 
     return combinations
 
+
 def exec_main(config):
 
     config["run_id"] = run_id
@@ -69,6 +76,7 @@ def exec_main(config):
     except Exception as e:
         print(utils.red("[XJOBS]"), "Running Error: {}, Continue...".format(e))
         return None
+
 
 GPU = get_gpu_by_user_input()
 

--- a/xjobs.py
+++ b/xjobs.py
@@ -8,21 +8,13 @@ import utils
 run_id = "RUN_{}".format(time.strftime("%Y%m%d-%H%M%S"))
 
 
-index = []
-run_config = {}
-run_configs = [
-    {
-        "tag": "lambda-no-win-two-sep",
-        "use_two_stage": True,
-        "use_independent_plm": True,
-    },
-    {
-        "tag": "lambda-no-win-two",
-        "use_two_stage": True,
-        "use_independent_plm": False,
-    }
-]
-
+index = ["use_rel_cls", "mask_token_position"]
+run_config = dict(
+    tag="zeta",
+    use_rel_cls=["lmhead", "multi_classifier"],
+    mask_token_position=["sub", "obj", "mid"]
+)
+run_configs = []
 
 def get_gpu_by_user_input():
 
@@ -90,14 +82,14 @@ args, _ = parser.parse_known_args()
 # 生成所有的组合
 combinations = get_all_combinations(run_config)
 
+for config in run_configs:
+    print(exec_main(config))
+
 for i, config in enumerate(combinations):
     config["tag"] = f"{config['tag']}"
     for key in index:
         if config.get(key):
             config["tag"] += f"-{key}_{config[key]}"
 
-    print(exec_main(config))
-
-for config in run_configs:
     print(exec_main(config))
 

--- a/xjobs.py
+++ b/xjobs.py
@@ -63,6 +63,7 @@ def exec_main(config):
 
     config["run_id"] = run_id
     config["fast_dev_run"] = args.fast_dev_run
+    config["output"] = args.output
     if not config.get("gpt") or config.get("gpt") not in ["0", "1", "2", "3"]:
         config["gpu"] = GPU
 
@@ -83,6 +84,7 @@ GPU = get_gpu_by_user_input()
 parser = argparse.ArgumentParser(add_help=False)
 # 添加一个 --fast-dev-run 的 argsparser 配置
 parser.add_argument("--fast-dev-run", action="store_true", help="Fast dev run")
+parser.add_argument("--output", type=str, default="output", help="Output directory")
 args, _ = parser.parse_known_args()
 
 # 生成所有的组合


### PR DESCRIPTION
在第二阶段的关系抽取中，加入了 mask 策略，并且通过实体过滤策略，对实体对的置信度排序，置信度由高到低排序，直到文本的长度超过 512 个长度限制为止。从实验效果来看，可以大大增加关系抽取的 recall，适当增加关系抽取的 precision。可能是由于实体对过滤模块，对原本的实体识别的模块有了一些不好的影响，相较于之前的双阶段模型，有 1% 的 f1 的分数下降。